### PR TITLE
Add support for two-way routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,12 @@ functions:
     events:
       - websocket:
           routeKey: message
+  twoWayMessage:
+    handler: handler.twoWay
+    events:
+      - websocket:
+          routeKey: twoway
+          # The property below will enable an integration response in the API Gateway.
+          # See https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-route-response.html
+          routeResponseSelectionExpression: $default
 ```


### PR DESCRIPTION
Adds support for two-way routes by using the routeResponseSelectionExpression property. When this property is set, RouteResponseSelectionExpression will be set on the Route and a RouteResponse is also created.

Example snippet from serverless.yml:
```
functions:
  chatMessage:
    handler: handler.chat
    events:
      - websocket:
          routeKey: message
          routeResponseSelectionExpression: $default
```

This should resolve issue #12